### PR TITLE
Locale decimal point character fix

### DIFF
--- a/src/Lifo/Daemon/Daemon.php
+++ b/src/Lifo/Daemon/Daemon.php
@@ -954,7 +954,7 @@ abstract class Daemon
      */
     protected function getLogPrefix()
     {
-        $time = array_pad(explode('.', microtime(true)), 2, 0);
+        $time = array_pad(explode(localeconv()['decimal_point'], microtime(true)), 2, 0);
         // timestamp + microseconds
 //        return sprintf("%s%04d: %d: ", date('Y-m-d H:i:s.', $time[0]), $time[1], $this->pid);
         return sprintf("%s%04d: %-6d %6d: ", date('Y-m-d H:i:s.', $time[0]), $time[1], $this->parentPid, getmypid());

--- a/src/Lifo/Daemon/Daemon.php
+++ b/src/Lifo/Daemon/Daemon.php
@@ -954,10 +954,8 @@ abstract class Daemon
      */
     protected function getLogPrefix()
     {
-        $time = array_pad(explode(localeconv()['decimal_point'], microtime(true)), 2, 0);
-        // timestamp + microseconds
-//        return sprintf("%s%04d: %d: ", date('Y-m-d H:i:s.', $time[0]), $time[1], $this->pid);
-        return sprintf("%s%04d: %-6d %6d: ", date('Y-m-d H:i:s.', $time[0]), $time[1], $this->parentPid, getmypid());
+        $time = explode(' ', microtime(), 2); // array (msec, sec)
+        return sprintf("%s%04d: %-6d %6d: ", date('Y-m-d H:i:s.', $time[1]), substr(round($time[0], 4), 2), $this->parentPid, getmypid());
     }
 
     /**


### PR DESCRIPTION
When user's code uses `setlocale` it takes notice:

> PHP Notice:  A non well formed numeric value encountered in …/vendor/lifo/php-daemon/src/Lifo/Daemon/Daemon.php on line 960

It happens because in some locales `decimal_point` is not a dot (comma `,` in my case).

Tested on PHP 5.5+