### PR TITLE
Support for PHP 8

### DIFF
--- a/src/Lifo/Daemon/IPC/SysV.php
+++ b/src/Lifo/Daemon/IPC/SysV.php
@@ -52,6 +52,14 @@ class SysV implements IPCInterface
         $this->setupIPC();
     }
 
+    private function check($var)
+    {
+        if(PHP_MAJOR_VERSION >= 8) {
+            return is_object($var);
+        }
+        return is_resource($var);
+    }
+
     private function purgeSEM()
     {
         if ($this->sem) {
@@ -62,7 +70,7 @@ class SysV implements IPCInterface
 
     private function purgeSHM()
     {
-        if (!is_resource($this->shm)) {
+        if (!$this->check($this->shm)) {
             $this->setupIPC();
         }
 
@@ -75,7 +83,7 @@ class SysV implements IPCInterface
 
     private function purgeQueue()
     {
-        if (!is_resource($this->queue)) {
+        if (!$this->check($this->queue)) {
             $this->setupIPC();
         }
 
@@ -93,12 +101,12 @@ class SysV implements IPCInterface
     {
         $this->sem = sem_get($this->mediator->getGuid());
         $this->shm = shm_attach($this->mediator->getGuid(), $this->size, 0666);
-        if (!is_resource($this->shm)) {
+        if (!$this->check($this->shm)) {
             throw new \Exception(sprintf("Could not attach to Shared Memory Block 0x%08x", $this->mediator->getGuid()));
         }
 
         $this->queue = msg_get_queue($this->mediator->getGuid(), 0666);
-        if (!is_resource($this->queue)) {
+        if (!$this->check($this->queue)) {
             throw new \Exception(sprintf("Could not attach to message queue 0x%08x", $this->mediator->getGuid()));
         }
     }
@@ -381,7 +389,7 @@ class SysV implements IPCInterface
      */
     private function testIpc()
     {
-        if (!is_resource($this->shm)) {
+        if (!$this->check($this->shm)) {
             return false;
         }
 


### PR DESCRIPTION
As of PHP version 8.0.0, several resources have been migrated to objects, including the semaphore functions used as part of the IPC class, notably `shm_attach` and `msg_get_queue`.

Attempting to run a worker daemon in PHP 8.x would throw a fatal error:

> Fatal Error: Could not attach to Shared Memory Block 0x65010630 in file: /var/daemons/vendor/lifo/php-daemon/src/Lifo/Daemon/IPC/SysV.php on line: 97

Per the PHP [migration guide for 7.4.x to 8.0.x](https://www.php.net/manual/en/migration80.incompatible.php#migration80.incompatible.resource2object), return value checks using `is_resource()` should be replaced with checks for `false`. 

This change introduces support for PHP 8.x, by using either `is_object` or `is_resource` depending on the PHP version.